### PR TITLE
Fixes read only issue. Adressing canjs/can-define#353

### DIFF
--- a/can-assign-test.js
+++ b/can-assign-test.js
@@ -13,3 +13,41 @@ QUnit.test("Assign all properties to an object", function(){
 		equal(expected[prop], actual[prop]);
 	}
 });
+
+QUnit.test("Works with readonly properties", function(){
+    var obj = {};
+    Object.defineProperty(obj, "a", {
+        value: "a",
+        writable: false
+    });
+
+    Object.defineProperty(obj, "b", {
+        value: "b",
+        writable: true
+    });
+
+    Object.defineProperty(obj, "c", {
+        get: function() { return "c" },
+        set: function(value){this.b = value;},
+        configurable: true
+    });
+
+    try {
+        assign(obj, {a:"c", b:"f", d: "d"});
+
+        QUnit.equal(obj.a, "a");
+				QUnit.equal(obj.b, "f");
+				QUnit.equal(obj.c, "c");
+				QUnit.equal(obj.d, "d");
+
+				assign(obj, {c:"h"});
+
+				QUnit.equal(obj.a, "a");
+				QUnit.equal(obj.b, "h");
+				QUnit.equal(obj.c, "c");
+				QUnit.equal(obj.d, "d");
+    } catch(err) {
+        QUnit.ok(false, err);
+    }
+
+});

--- a/can-assign.js
+++ b/can-assign.js
@@ -30,7 +30,10 @@ var namespace = require("can-namespace");
 
 module.exports = namespace.assign = function (d, s) {
 	for (var prop in s) {
-		d[prop] = s[prop];
+		var desc = Object.getOwnPropertyDescriptor(d,prop);
+		if(!desc || desc.writable !== false){
+			d[prop] = s[prop];
+		}
 	}
 	return d;
 };


### PR DESCRIPTION
Strict mode in can-assign causes an error to throw when trying to assign read-only properties. Added check to skip read-only properties. Same behavior as seen in non-strict mode.