### PR TITLE
Fix the steal config

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,13 @@
     "develop": "done-serve --static --develop --port 8080",
     "detect-cycle": "detect-cyclic-packages --ignore done-serve"
   },
-  "main": "dist/cjs/can-assign",
+  "main": "can-assign",
   "keywords": [
     "canjs",
     "object",
     "assign"
   ],
   "steal": {
-    "main": "can-assign",
     "configDependencies": [
       "live-reload"
     ],


### PR DESCRIPTION
- Update the main in `package.json` to `can-assign` instead of the build
- Remove the main in the steal config

Fixes https://github.com/canjs/can-assign/issues/19